### PR TITLE
fix: reserved AudioParams missing under poly

### DIFF
--- a/src/FaustAudioWorkletNode.ts
+++ b/src/FaustAudioWorkletNode.ts
@@ -188,10 +188,13 @@ export class FaustAudioWorkletNode extends (window.AudioWorkletNode ? AudioWorkl
     setParamValue(path: string, value: number) {
         const e = { type: "param", data: { path, value } };
         this.port.postMessage(e);
-        this.parameters.get(path).setValueAtTime(value, 0);
+        const param = this.parameters.get(path);
+        if (param) param.setValueAtTime(value, this.context.currentTime);
     }
     getParamValue(path: string) {
-        return this.parameters.get(path).value;
+        const param = this.parameters.get(path);
+        if (param) return param.value;
+        return null;
     }
     setOutputParamHandler(handler: (address: string, value: number) => any) {
         this.outputHandler = handler;


### PR DESCRIPTION
Previous PR synchronises AudioWorklet AudioParams with Faust's inner params. However, under poly mode, gain, freq and gate are reserved and connot be found in AudioParam Map of AudioWorklet Node, causes undefined error when changed. This fix double-checks whether the parameter exists before set it.