### PR TITLE
fix: overload getNode to return correct type

### DIFF
--- a/src/Faust.ts
+++ b/src/Faust.ts
@@ -109,6 +109,7 @@ export class Faust {
      * @param {string} code - the source code
      * @param {TFaustCompileOptions} optionsIn - options with audioCtx, bufferSize, voices, useWorklet, args, plot and plotHandler
      */
+    async getNode<O extends TFaustCompileOptions>(code: string, optionsIn: O): Promise<O["useWorklet"] extends true ?  FaustAudioWorkletNode : FaustScriptProcessorNode> 
     async getNode(code: string, optionsIn: TFaustCompileOptions): Promise<FaustAudioWorkletNode | FaustScriptProcessorNode> {
         const { audioCtx, voices, useWorklet, bufferSize, plotHandler, args } = optionsIn;
         const argv = utils.toArgv(args);


### PR DESCRIPTION
at the moment we receive a type-error in the following situation:
![afbeelding](https://user-images.githubusercontent.com/10504064/193888862-14854ff1-54af-41b9-a497-9bacf0017892.png)

this type-error happens because `Property 'connect' does not exist on type 'FaustAudioWorkletNode'` although we had specified in the options-config that `useWorklet: false`

I propose to overload the getNode-function, like below, so typescript can infer the correct type from the config
![afbeelding](https://user-images.githubusercontent.com/10504064/193889197-5617fcc0-c81d-48d1-b480-4d363a1a3ff7.png)

the result:
![afbeelding](https://user-images.githubusercontent.com/10504064/193889451-09ce2725-840b-4e37-b26d-46ca5c3d0985.png)
![afbeelding](https://user-images.githubusercontent.com/10504064/193889481-ffebe820-201b-4c4a-8b10-ef739f10c7f8.png)

we receive a type-error when we try to use `.connect` when we specified `useWorklet: true` and don't get one when  `useWorklet: false`